### PR TITLE
Allow macOS to have supervised keys

### DIFF
--- a/ProfilePayloads/ProfilePayloads/ProfilePayloads.swift
+++ b/ProfilePayloads/ProfilePayloads/ProfilePayloads.swift
@@ -14,7 +14,7 @@ public class ProfilePayloads {
     //  Variables
     // ---------------------------------------------------------------------
     public static let shared = ProfilePayloads()
-    public static let platformsSupervised: Platforms = [.iOS, .tvOS]
+    public static let platformsSupervised: Platforms = [.iOS, .tvOS, .macOS]
     public static let platformsUserApproved: Platforms = [.macOS]
     public static let rangeListConvertMax = 40
 

--- a/ProfilePayloads/ProfilePayloads/Utility/Constants.swift
+++ b/ProfilePayloads/ProfilePayloads/Utility/Constants.swift
@@ -891,8 +891,6 @@ public enum ManifestKey: String {
      **Bool**
 
      Requires the device to be supervised for this key or payload to work.
-
-     _Note_: iOS and tvOS only
      */
     case supervised = "pfm_supervised"
 


### PR DESCRIPTION
Resolve https://github.com/ProfileCreator/ProfileCreator/issues/253. Note we will still have to update the manifests to show that all supervised keys require macOS 10.14.4 and later as specified here https://support.apple.com/guide/deployment/about-device-supervision-dep1d89f0bff/web. Will need to update ProfileCreator with the changes in this framework.